### PR TITLE
Remove Google+ integration (service shut down in 2019)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,6 @@ social:
    github:         julien731
    twitter:        julien731
    email:          julien@liabeuf.fr
-   googleplus:     +JulienLiabeuf
 
 google_analytics:  "G-8L5KEN74L9"
 

--- a/_includes/structured_data_page.html
+++ b/_includes/structured_data_page.html
@@ -13,8 +13,7 @@
 			"name":"Julien Liabeuf",
 			"sameAs":[
 				"https://twitter.com/{{ site.social.twitter }}",
-				"https://github.com/{{ site.social.github }}",
-				"https://plus.google.com/u/0/{{ site.social.googleplus }}"
+				"https://github.com/{{ site.social.github }}"
 			]
 	},
 	"publisher":{
@@ -22,8 +21,7 @@
 		"name":"Julien Liabeuf",
 		"sameAs":[
 			"https://twitter.com/{{ site.social.twitter }}",
-			"https://github.com/{{ site.social.github }}",
-			"https://plus.google.com/u/0/{{ site.social.googleplus }}"
+			"https://github.com/{{ site.social.github }}"
 		]
 	},
 	"mainEntityOfPage":{

--- a/_includes/structured_data_post.html
+++ b/_includes/structured_data_post.html
@@ -15,8 +15,7 @@
 			"name":"Julien Liabeuf",
 			"sameAs":[
 				"https://twitter.com/{{ site.social.twitter }}",
-				"https://github.com/{{ site.social.github }}",
-				"https://plus.google.com/u/0/{{ site.social.googleplus }}"
+				"https://github.com/{{ site.social.github }}"
 			]
 	},
 	"publisher":{
@@ -24,8 +23,7 @@
 		"name":"Julien Liabeuf",
 		"sameAs":[
 			"https://twitter.com/{{ site.social.twitter }}",
-			"https://github.com/{{ site.social.github }}",
-			"https://plus.google.com/u/0/{{ site.social.googleplus }}"
+			"https://github.com/{{ site.social.github }}"
 		]
 	},
 	"mainEntityOfPage":{

--- a/index.html
+++ b/index.html
@@ -38,8 +38,7 @@ title: Julien Liabeuf
       "name": "Julien Liabeuf",
       "sameAs": [
           "https://twitter.com/{{ site.social.twitter }}",
-          "https://github.com/{{ site.social.github }}",
-          "https://plus.google.com/u/0/{{ site.social.googleplus }}"
+          "https://github.com/{{ site.social.github }}"
       ]
     }
   }

--- a/work.html
+++ b/work.html
@@ -39,8 +39,7 @@ title: Work and Experiences
       "name": "Julien Liabeuf",
       "sameAs": [
           "https://twitter.com/{{ site.social.twitter }}",
-          "https://github.com/{{ site.social.github }}",
-          "https://plus.google.com/u/0/{{ site.social.googleplus }}"
+          "https://github.com/{{ site.social.github }}"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Remove `googleplus` from social config in _config.yml
- Remove Google+ URLs from structured data (schema.org sameAs arrays)
- Affects: index.html, work.html, structured_data_page.html, structured_data_post.html

Google+ was shut down in April 2019. This removes dead code and prevents broken links.

## Test plan
- [ ] Site builds without errors
- [ ] Structured data validates (no broken sameAs URLs)

Resolves #581