### PR TITLE
fix: correct invalid JSON-LD in page and comment structured data

### DIFF
--- a/_includes/structured_data_comment.html
+++ b/_includes/structured_data_comment.html
@@ -4,11 +4,11 @@
 	"@type":"Comment",
 	"author":{
 		"@type":"Person",
-		"name":"{{ include.name }}",
+		"name":{{ include.name | jsonify }},
 		"url":"{{ include.url }}"
 	},
 	"datePublished":"{{ include.date | date_to_xmlschema }}",
 	"discussionUrl":"{{ site.url }}#comment{% if r %}{{ index | prepend: '-' }}{% else %}{{ include.index | prepend: '-' }}{% endif %}",
-	"text":"{{ include.message }}"
+	"text":{{ include.message | jsonify }}
 	}
 </script>

--- a/_includes/structured_data_page.html
+++ b/_includes/structured_data_page.html
@@ -5,7 +5,7 @@
 	"headline":"{{ page.title }}",
 	"wordCount":"{{ page.content | number_of_words }}",
 	"url":"{{ page.url | prepend: site.url }}",
-	"datePublished":"{{ page.date | | date: '%Y-%m-%d' }}",
+	"datePublished":"{{ page.date | date: '%Y-%m-%d' }}",
 	"dateModified":"{{ page.dateModified | default: page.date | date: '%Y-%m-%d' }}",
 	"image":"{{ page.image | default: 'notebook.jpg' | prepend: '/assets/img/' | prepend: site.url }}",
 	"author":{
@@ -28,6 +28,6 @@
 		"@type":"WebPage",
 		"@id":"{{ page.url | prepend: site.url }}"
 	},
-	"articleBody":"{{ page.content | strip_html | xml_escape | normalize_whitepace | strip_newlines | strip }}"
+	"articleBody":{{ page.content | strip_html | strip_newlines | strip | jsonify }}
 	}
 </script>


### PR DESCRIPTION
## Problem
Same bugs as the post structured data (already fixed directly on `develop` — sorry, that was a Gitflow violation on my end):

- `articleBody` used `xml_escape` which outputs HTML entities (`&apos;`, `&amp;`) — invalid in JSON
- `normalize_whitepace` was **misspelled** so it never ran, letting raw control characters through
- `datePublished` had a double-pipe typo `| |`
- Comment `text` and `name` fields could contain quotes/backslashes that break JSON

## Fix
- Replaced the broken filter chain with Jekyll's built-in `jsonify` which properly JSON-encodes strings (escapes backslashes, quotes, control characters)
- Fixed `datePublished` double-pipe in `structured_data_page.html`
- Applied `jsonify` to comment `name` and `message` fields

## Files changed
- `_includes/structured_data_page.html`
- `_includes/structured_data_comment.html`